### PR TITLE
fix: link of "Ethereum foundation zkEVM"

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Feel free to PR.
 ## Projects
 
 - [Zcash Protocol NU5: Orchard](https://github.com/zcash/orchard)
-- [Ethereum foundation zkEVM](https://github.com/zcash/orchard)
+- [Ethereum foundation zkEVM](https://github.com/privacy-scaling-explorations/zkevm-specs)
 - [Darkrenaissance's Dark.fi](https://github.com/darkrenaissance/darkfi)
 
 ## Gadgets 


### PR DESCRIPTION
## What's wrong?
"Ethereum foundation zkEVM" is linked to [zcash/orchard](https://github.com/zcash/orchard) which seems to be incorrect.

## How it's fixed?
Link it to [privacy-scaling-explorations/zkevm-specs](https://github.com/privacy-scaling-explorations/zkevm-specs). Please feel free to change it if it's not the correct site.